### PR TITLE
ci: add GHCR publish workflow and update README

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,64 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: |
+            ghcr.io/${{ env.IMAGE_NAME }}
+            ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -1,76 +1,61 @@
 # static-server
 
-> 🐝 A static server based on superstatic
+> 🐝 A static server based on [superstatic](https://github.com/firebase/superstatic)
+
+## Docker Image
+
+```
+beeman/static-server
+```
+
+Also available on GitHub Container Registry as `ghcr.io/beeman/static-server`.
+
+## Usage
+
+The easiest way to use this is with `docker-compose` — no Dockerfile needed:
+
+```yaml
+services:
+  web:
+    image: beeman/static-server:latest
+    volumes:
+      - ./dist:/app
+    ports:
+      - 9876:9876
+    environment:
+      - ENV_API_URL=https://api.example.com/
+```
+
+Or with a `Dockerfile` if you prefer baking the files into the image:
+
+```Dockerfile
+FROM beeman/static-server:latest
+COPY dist /app/
+```
 
 ## Configuration
 
-`PORT`
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PORT` | `9876` | Port the server listens on |
+| `ROOT` | `./app` | Directory to serve |
+| `COMPRESSION` | `true` | Toggle compression |
+| `DEBUG` | `false` | Toggle debug logging |
+| `ENV_PREFIX` | `ENV_` | Prefix for env vars passed to the client |
+| `HTTP_AUTH_USER` | — | Username for Basic HTTP Authentication |
+| `HTTP_AUTH_PASS` | — | Password for Basic HTTP Authentication |
 
-> The port on which this server listens (default: 9876)
+## Environment Passthrough
 
-`ROOT`
+The server makes environment variables available to the static client at runtime.
 
-> The directory that is served (default: './app')
+Any env var prefixed with `ENV_` (configurable via `ENV_PREFIX`) is exposed to the client via:
 
-`COMPRESSION`
+- `/__/env.js` — sets `window.__env` with the variables
+- `/__/env.json` — JSON object of the variables
 
-> Toggle compression (default: true)
-
-`DEBUG`
-
-> Toggle debugging (default: false)
-
-`ENV_PREFIX`
-
-> Prefix of ENV VARS passed to the client (read below) (default: 'ENV_')
-
-`HTTP_AUTH_USER` and `HTTP_AUTH_USER`
-
-> Username and password to use for Basic HTTP Authentication
-
-## Environment
-
-The server allows making environment variables available to the static client.
-
-It will parse all the environment variables that are prefixed with `ENV_` and make them available to the client.
-
-The client can read the file `/__/env.js` or  `/__/env.json` to access these variables.
-
-In case of `/__/env.js` there will be an object available on `window.__env`.
-
-## Docker
-
-This server is available as a Docker image.
-
-This is an example on how to use it from a `Dockerfile`:
-
-```Dockerfile
-# Base image.
-FROM beeman/static-server:latest
-
-# Copy the app to the image
-COPY dist /app/
-
-# Expose the default port
-EXPOSE 9876
-
-# Run application.
-CMD ["node", "/app/index.js"]
-```
-
-This is an example on how to use it with `docker-compose`:
-
-```yaml
-static:
-  image: beeman/static-server:latest
-  volumes:
-    - ./app:/app
-  ports:
-    - 9876:9876
-  environment:
-    - ENV_API_URL=https://api.example.com/
-```
+This lets you configure your SPA at deploy time without rebuilding.
 
 ## License
 
-MIT - Copyright (c) 2016-2019 Bram Borggreve
+MIT - Copyright (c) 2016-2026 Bram Borggreve


### PR DESCRIPTION
## Changes

- **GitHub Actions workflow** that builds and pushes the Docker image to `ghcr.io/beeman/static-server` on push to main and on version tags
  - Builds on PRs (no push) to catch issues early
  - Tags: branch name, semver (`v1.2.3` → `1.2.3`, `1.2`, `1`), and git SHA
  - Uses GHA build cache for fast rebuilds
- **README overhaul**
  - Links to superstatic repo
  - Points to GHCR as primary image location (notes Docker Hub as legacy)
  - Leads with docker-compose usage (no Dockerfile needed)
  - Config table instead of individual blocks
  - Fixes `HTTP_AUTH_USER`/`HTTP_AUTH_PASS` typo
  - Updates license year